### PR TITLE
Replace docker push/pull with the regsync command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM regclient/regsync:v0.3.9-alpine
+
+# Change user to root for the purpose of doing our installs, and
+# the way Github Actions run we need to have access to write to
+# /home/github to create our docker credentials file.
+USER root
+
+# Needed to log into the ECR repository
+RUN apk update && apk add aws-cli docker-credential-ecr-login
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ _There is specifically no `docker build ...` code in this action on purpose._
    good.
 4. Developer tags (or uses a Github Release) `$SHA` in Git repository as
    `v1.2.3`
-5. This action is triggered to `docker pull myapp:test-$SHA && docker tag ...
-   && docker push`
+5. This action is triggered which uses the
+   [regsync](https://github.com/regclient/regclient) tool to re-tag the release
+   with your target tag and push that up. Using `regsync` ensures that we are
+   multi-arch compatible, and we only pull down the necessary bits.
 
 ## Usage
 
@@ -92,3 +94,19 @@ push that image.
 If your `image` value points to an AWS ECR repository, then the action will
 automatically log into AWS on your behalf. It expects that you will set the
 `AWS_ACCES_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+
+# Development Notes
+
+To test out this function, you need to log into your own ECR repository and
+pass the credentials into the Docker image. Here's an example of doing it
+locally with an `$HOME/.aws/credentials` file in place:
+
+    $ docker build . -t myimage && \
+      docker run \
+        --volume $HOME/.aws:/home/appuser/.aws \
+        --env INPUT_IMAGE=111111111111.dkr.ecr.us-west-2.amazonaws.com/myorg/myimage \
+        --env INPUT_SOURCE_TAG=latest \
+        --env INPUT_DEST_TAG=foobar \
+        --env AWS_PROFILE=eng \
+        --env INPUT_DRY=false \
+        --env INPUT_VERBOSE=true myimage

--- a/action.yml
+++ b/action.yml
@@ -32,13 +32,11 @@ inputs:
     default: 'false'
 
 runs:
-  using: composite
-  steps:
-    - shell: bash
-      run: $GITHUB_ACTION_PATH/entrypoint.sh
-      env:
-        INPUT_IMAGE: ${{ inputs.image }}
-        INPUT_SOURCE_TAG: ${{ inputs.source_tag }}
-        INPUT_DEST_TAG: ${{ inputs.dest_tag }}
-        INPUT_VERBOSE: ${{ inputs.verbose }}
-        INPUT_DRY: ${{ inputs.dry }}
+  using: docker
+  image: Dockerfile
+  env:
+    INPUT_IMAGE: ${{ inputs.image }}
+    INPUT_SOURCE_TAG: ${{ inputs.source_tag }}
+    INPUT_DEST_TAG: ${{ inputs.dest_tag }}
+    INPUT_VERBOSE: ${{ inputs.verbose }}
+    INPUT_DRY: ${{ inputs.dry }}


### PR DESCRIPTION
**What did I want**

In order to support multi-arch image retagging, we need to stop doing `docker pull/push` because that only pulls down a single image. Also that takes longer than is necessary.

**What did I do?**

I converted this action into a Docker-image based action where we build a Docker image with `regsync` and the `docker-cli` built in. The `regsync` command is used to do the replication, which is much smarter and faster... and will replicate the manifest only, which is all we need in this case. This greatly speeds up the action, AND makes it multi-arch compatible.